### PR TITLE
Prevent adding duplicate var name to proto

### DIFF
--- a/examples/json_queries/issue_10_duplicate_vars.json
+++ b/examples/json_queries/issue_10_duplicate_vars.json
@@ -1,0 +1,11 @@
+{
+  "proto": {
+    "id": "?label$required",
+    "name": "?label$required"
+  },
+  "$where": [
+    "?id a dbo:City",
+    "?id rdfs:label ?label"
+  ],
+  "$limit": 10
+}

--- a/examples/json_transformed/issue_10_duplicate_vars.json
+++ b/examples/json_transformed/issue_10_duplicate_vars.json
@@ -1,0 +1,102 @@
+[
+  {
+    "id": {
+      "language": "en",
+      "value": "Acre, Israel"
+    },
+    "name": {
+      "language": "en",
+      "value": "Acre, Israel"
+    }
+  },
+  {
+    "id": {
+      "language": "ar",
+      "value": "عكا"
+    },
+    "name": {
+      "language": "ar",
+      "value": "عكا"
+    }
+  },
+  {
+    "id": {
+      "language": "de",
+      "value": "Akkon"
+    },
+    "name": {
+      "language": "de",
+      "value": "Akkon"
+    }
+  },
+  {
+    "id": {
+      "language": "es",
+      "value": "Acre (Israel)"
+    },
+    "name": {
+      "language": "es",
+      "value": "Acre (Israel)"
+    }
+  },
+  {
+    "id": {
+      "language": "fr",
+      "value": "Acre (Israël)"
+    },
+    "name": {
+      "language": "fr",
+      "value": "Acre (Israël)"
+    }
+  },
+  {
+    "id": {
+      "language": "it",
+      "value": "Acri (Israele)"
+    },
+    "name": {
+      "language": "it",
+      "value": "Acri (Israele)"
+    }
+  },
+  {
+    "id": {
+      "language": "ja",
+      "value": "アッコ"
+    },
+    "name": {
+      "language": "ja",
+      "value": "アッコ"
+    }
+  },
+  {
+    "id": {
+      "language": "nl",
+      "value": "Akko (stad)"
+    },
+    "name": {
+      "language": "nl",
+      "value": "Akko (stad)"
+    }
+  },
+  {
+    "id": {
+      "language": "pl",
+      "value": "Akka"
+    },
+    "name": {
+      "language": "pl",
+      "value": "Akka"
+    }
+  },
+  {
+    "id": {
+      "language": "pt",
+      "value": "Acre (Israel)"
+    },
+    "name": {
+      "language": "pt",
+      "value": "Acre (Israel)"
+    }
+  }
+]

--- a/examples/sparql_output/issue_10_duplicate_vars.json
+++ b/examples/sparql_output/issue_10_duplicate_vars.json
@@ -1,0 +1,82 @@
+{
+  "head": {
+    "link": [],
+    "vars": ["label"]
+  },
+  "results": {
+    "distinct": false,
+    "ordered": true,
+    "bindings": [
+      {
+        "label": {
+          "type": "literal",
+          "xml:lang": "en",
+          "value": "Acre, Israel"
+        }
+      },
+      {
+        "label": {
+          "type": "literal",
+          "xml:lang": "ar",
+          "value": "\u0639\u0643\u0627"
+        }
+      },
+      {
+        "label": {
+          "type": "literal",
+          "xml:lang": "de",
+          "value": "Akkon"
+        }
+      },
+      {
+        "label": {
+          "type": "literal",
+          "xml:lang": "es",
+          "value": "Acre (Israel)"
+        }
+      },
+      {
+        "label": {
+          "type": "literal",
+          "xml:lang": "fr",
+          "value": "Acre (Isra\u00EBl)"
+        }
+      },
+      {
+        "label": {
+          "type": "literal",
+          "xml:lang": "it",
+          "value": "Acri (Israele)"
+        }
+      },
+      {
+        "label": {
+          "type": "literal",
+          "xml:lang": "ja",
+          "value": "\u30A2\u30C3\u30B3"
+        }
+      },
+      {
+        "label": {
+          "type": "literal",
+          "xml:lang": "nl",
+          "value": "Akko (stad)"
+        }
+      },
+      {
+        "label": {
+          "type": "literal",
+          "xml:lang": "pl",
+          "value": "Akka"
+        }
+      },
+      {
+        "label": {
+          "type": "literal",
+          "xml:lang": "pt",
+          "value": "Acre (Israel)"
+        }
+      }
+    ]
+  }
+}

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -309,7 +309,9 @@ function manageProtoKey(proto, vars = [], filters = [], wheres = [], mainLang = 
 
       aVar = `(sql:BEST_LANGMATCH(${id}, "${lng}", "en") AS ${id})`;
     }
-    vars.push(aVar);
+    if (!vars.includes(aVar)) {
+      vars.push(aVar);
+    }
 
     const langStr = options.find(o => o.match(LANG_REGEX));
     let langfilter = '';

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -436,7 +436,8 @@ ${filters.map(f => `${INDENT}FILTER(${f})`).join('\n')}
 }
 
 
-export default function (input, options = {}) {
+export default function (baseInput, options = {}) {
+  const input = objectAssignDeep({}, baseInput);
   const opt = Object.assign({},
     DEFAULT_OPTIONS, {
       context: input['@context'],

--- a/test.js
+++ b/test.js
@@ -79,3 +79,14 @@ test('No lang tag', async (t) => {
 
   t.deepEqual(out, expected);
 });
+
+test('Duplicate variable name', async (t) => {
+  const file = 'issue_10_duplicate_vars.json';
+  const [orig, q, expected] = loadFiles(file);
+  mock(orig);
+
+  const out = await sparqlTransformer(q);
+  // fs.writeFileSync('a.json', JSON.stringify(out, null, 2), 'utf-8');
+
+  t.deepEqual(out, expected);
+});


### PR DESCRIPTION
This fixes duplicate variable name in the SELECT section of the generated SPARQL query.

Fixes #10