### PR TITLE
Check for value of opt.debug to set debug level

### DIFF
--- a/src/main.mjs
+++ b/src/main.mjs
@@ -444,7 +444,9 @@ export default function (baseInput, options = {}) {
     }, options);
 
   if (opt.env && opt.env.DEBUG_LEVEL) debug.level = opt.env.DEBUG_LEVEL;
-  if (opt.debug) debug.level = 'debug';
+  // Override debug level if `debug` option is set
+  if (opt.debug === true) debug.level = 'debug';
+  if (opt.debug === false) debug.level = 'log';
 
   debug.verbose('options:', JSON.stringify(opt, null, 2));
 


### PR DESCRIPTION
Currently, if `opt.debug` is set to `true` for the first call, debug level will be set to "debug". If `opt.debug` is then changed to `false`, debug level remains unchanged, which is wrong.

This change makes sure that debug level is reset back to its default value ("log") in case we set `opt.debug` to `false`.

**Current behavior (before this fix):**

* First call: `sparqlTransformer(query, { debug: true });`
debug level: "debug"

* Second call: `sparqlTransformer(query, { debug: false });`
debug level: "debug"

**New behavior (after this fix):**

* First call: `sparqlTransformer(query, { debug: true });`
debug level: "debug"

* Second call: `sparqlTransformer(query, { debug: false });`
debug level: "log"