### PR TITLE
Fix return value for computeRootId when no anchor was set

### DIFF
--- a/src/main.mjs
+++ b/src/main.mjs
@@ -238,7 +238,7 @@ function computeRootId(proto, prefix) {
   // otherwise, check if one of the default anchors is there
   if (!k) {
     k = Object.keys(KEY_VOCABULARIES).find(key => !!proto[KEY_VOCABULARIES[key].id]);
-    if (!k) return null;
+    if (!k) return [null, false];
 
     k = KEY_VOCABULARIES[k].id;
   }


### PR DESCRIPTION
When there is no anchor, `computeRootId` currently returns `[null]`, while `manageProtoKey` expects an array with 2 values (string, boolean) instead. This pull request fixes it by returning `[null, false]`.