### PR TITLE
Add support for additional HTTP query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ The `options` parameter is optional, and can define the following:
 | sparqlFunction | `null` | A function receiving in input the transformed query in SPARQL, returning a Promise. If not specified, the module performs the query on its own<sup id="a1">[1](#f1)</sup> against the specified endpoint.  |
 | endpoint | http://dbpedia.org/sparql | Used only if `sparqlFunction` is not specified. |
 | debug | `false` | Enter in debug mode. This allow to print in console the generated SPARQL query. |
+| params | `{}` | Additional parameters to pass to the HTTP query |
 
 
 See [`test.js`](./test.js) for further examples.

--- a/src/main.mjs
+++ b/src/main.mjs
@@ -30,7 +30,7 @@ const AGGREGATES = ['sample', 'count', 'sum', 'min', 'max', 'avg'];
 
 function defaultSparql(endpoint) {
   const client = new SparqlClient(endpoint);
-  return q => client.query(q);
+  return (q, params) => client.query(q, params);
 }
 
 const XSD = 'http://www.w3.org/2001/XMLSchema#';
@@ -501,7 +501,7 @@ export default function (baseInput, options = {}) {
 
   const sparqlFun = opt.sparqlFunction || defaultSparql(opt.endpoint);
 
-  return sparqlFun(query).then((sparqlRes) => {
+  return sparqlFun(query, opt.params).then((sparqlRes) => {
     const { bindings } = sparqlRes.results;
     let content = [];
 

--- a/src/sparql-client.mjs
+++ b/src/sparql-client.mjs
@@ -18,8 +18,8 @@ export default class SparqlClient {
     this.endpoint = endpoint;
   }
 
-  query(q) {
-    return axios.post(this.endpoint, new URLSearchParams({ query: q })).then((res) => {
+  query(q, params = {}) {
+    return axios.post(this.endpoint, new URLSearchParams({ ...params, query: q })).then((res) => {
       if (res.status === 200) return res.data;
       throw new Error(res.statusText);
     });


### PR DESCRIPTION
Lets the user specify custom HTTP parameters to be passed in the query. This is particulary useful if the graph server requires additional parameters.

For example, with GraphDB you can disable owl:sameAs relations by adding `sameAs=false` into the request URL. With this change, it becomes possible by doing:

```js
sparqlTransformer(query, {
  params: {
    sameAs: false
  }
});
```